### PR TITLE
Creates a new flag to specify timestamp formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ on every system. The binaries can be found in the respective releases [here](htt
 
 ## Usage
 
-### -container (required)
+### --container | -C (required)
 
 The container parameter specifies the name of the container for which the metrics are to be gathered. It is required as
 this is the core point of caree,
 
-### -interval
+### --interval | -I
 
 The interval parameter can specify the duration between each data point collected by caree.
 
@@ -41,7 +41,7 @@ The interval parameter can specify the duration between each data point collecte
 
 #### Units: "ns", "us" (or "µs"), "ms", "s", "m", "h"
 
-### -format
+### --format | -F
 
 The format parameter specifies in which format the output is printed. As of right now the follow formats exist.
 
@@ -50,6 +50,18 @@ The format parameter specifies in which format the output is printed. As of righ
   complete json string.
 
 #### Default: JSON
+
+### --timestamp | -T
+
+The timestamp parameter specifies in which format the timestamp for each data point is going to be printed. As of right
+now the following formats exist.
+
+- 'ISO' specifies the time format to follow [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html), more
+  specifically [RFC3339](https://tools.ietf.org/html/rfc3339), when printing the timestamps.
+- 'EPOCH' specifies the timestamp to follow simple [unix epoch](https://en.wikipedia.org/wiki/Unix_time). The timestamp
+  will be represented as **milliseconds**.
+
+#### Default: EPOCH
 
 ------------------------------------------------------------------------------------------------------------------------
 

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/docker/docker/client"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -18,15 +19,21 @@ var (
 )
 
 type OutputMode = uint
+type TimestampFormat = uint
 
 const (
 	CSV  OutputMode = iota
 	JSON OutputMode = iota
 )
+const (
+	ISO   TimestampFormat = iota
+	EPOCH TimestampFormat = iota
+)
 
 type DisplayContext struct {
 	Name         string
 	OutputFormat OutputMode
+	TimestampFormat
 }
 
 func DisplayCurrentStats(dockerClient *client.Client, ctx DisplayContext) {
@@ -41,7 +48,7 @@ func DisplayCurrentStats(dockerClient *client.Client, ctx DisplayContext) {
 		for i := range result.Processes {
 			process := result.Processes[i]
 			processValues := make(map[string]string)
-			processValues["TIMESTAMP"] = time.Now().String()
+			processValues["TIMESTAMP"] = GetCurrentTime(ctx.TimestampFormat)
 			for j := range process {
 				processValues[result.Titles[j]] = process[j]
 			}
@@ -58,7 +65,7 @@ func DisplayCurrentStats(dockerClient *client.Client, ctx DisplayContext) {
 		}
 
 		for i := range result.Processes {
-			fmt.Println(strings.Join(result.Processes[i], ",") + "," + time.Now().String())
+			fmt.Println(strings.Join(result.Processes[i], ",") + "," + GetCurrentTime(ctx.TimestampFormat))
 		}
 	}
 }
@@ -71,5 +78,25 @@ func ParseOutputFormat(str string) (OutputMode, error) {
 		return JSON, nil // Different case than the default case, JSON was parsed correctly!
 	default:
 		return JSON, errors.New("failed to parse output format; defaulting to JSON")
+	}
+}
+
+func ParseTimestampFormat(str string) (TimestampFormat, error) {
+	switch strings.ToUpper(str) {
+	case "ISO":
+		return ISO, nil
+	case "EPOCH":
+		return EPOCH, nil // Different case than the default case, JSON was parsed correctly!
+	default:
+		return EPOCH, errors.New("failed to parse timestamp format; defaulting to epoch")
+	}
+}
+
+func GetCurrentTime(format TimestampFormat) string {
+	switch format {
+	case ISO:
+		return time.Now().Format(time.RFC3339)
+	default:
+		return strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,10 +11,12 @@ import (
 
 func Execute(ctx *cli.Context) error {
 	outputFormat, err := ParseOutputFormat(ctx.String("format"))
+	timestampFormat, err := ParseTimestampFormat(ctx.String("timestamp"))
 
 	context := DisplayContext{
-		Name:         ctx.String("container"),
-		OutputFormat: outputFormat,
+		Name:            ctx.String("container"),
+		OutputFormat:    outputFormat,
+		TimestampFormat: timestampFormat,
 	}
 
 	dockerClient, err := client.NewEnvClient()

--- a/main.go
+++ b/main.go
@@ -29,6 +29,12 @@ func main() {
 				Value:   "JSON",
 				Usage:   "output format of caree",
 			},
+			&cli.StringFlag{
+				Name:    "timestamp",
+				Aliases: []string{"T"},
+				Value:   "EPOCH",
+				Usage:   "output format of the timestamps carre generates",
+			},
 			&cli.DurationFlag{
 				Name:    "interval",
 				Aliases: []string{"I"},


### PR DESCRIPTION
The ability to specify the timestamp format besides the previous default
ISO has become increasingly neccesary as users may require different
formats for their respective timestamps when merging the data provided
by carre with other tools.

This commit provides this feature through the --timestamp or -T flag
when calling the carre cli.